### PR TITLE
Update YML to fix gem install command problem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ branches:
 language: objective-c
 osx_image: xcode10
 install:
-- gem install xcpretty -N --no-ri --no-rdoc
+- gem install xcpretty
 script:
 - set -o pipefail && xcodebuild -workspace AppDevKit.xcworkspace -scheme AppDevKit -sdk iphonesimulator12.0 -destination 'platform=iOS Simulator,name=iPhone 6,OS=10.0' build test GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES | xcpretty -c
 after_success:


### PR DESCRIPTION
The origin command: 'gem install xcpretty -N --no-ri --no-rdoc' will cause error report. The problem is the version of gem is too old.